### PR TITLE
Removed call that eventually cause API to crash

### DIFF
--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
@@ -190,7 +190,6 @@ public class Kind2LanguageServer
         workingDirectory = client.workspaceFolders().get().get(0).getUri();
       }
       Kind2Api api = getPresetKind2Api();
-      api.setOldFrontend(false);
       api.setOnlyParse(true);
       api.setLsp(true);
       String filepath = computeRelativeFilepath(workingDirectory, uri);


### PR DESCRIPTION
 The following line 

           api.setOldFrontend(false);

caused the Kind2 Java API to crash when calling api.execute() later.
Language server works fine without this line, not sure if old_frontend is even supported anymore

The API specifically threw

            Not a JSON Array: {"objectType":"log","level":"error","source":"parse","value":"Unknown flag '--old_frontend'"}  

So the Kind2 output should be [{"objectType":"log","level":"error","source":"parse","value":"Unknown flag '--old_frontend'"}], or the Kind2 Java API should handle this case in a clean way.
