### PR TITLE
LSP parse error handling

### DIFF
--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
@@ -971,7 +971,12 @@ private MCSCategory stringToMCSCategory(String cat){
         CompletableFuture.runAsync(() -> {
           parse(uri);
           client.updateComponents(uri);
-        });
+        })
+        .exceptionally(ex -> {
+            client.showMessage(new MessageParams(MessageType.Error, "Fatal error during parsing: " + ex.getMessage()));
+            return null;
+        })
+        ;
       }
 
       @Override
@@ -982,7 +987,12 @@ private MCSCategory stringToMCSCategory(String cat){
         CompletableFuture.runAsync(() -> {
           parse(uri);
           client.updateComponents(uri);
-        });
+        })
+        .exceptionally(ex -> {
+            client.showMessage(new MessageParams(MessageType.Error, "Fatal error during parsing: " + ex.getMessage()));
+            return null;
+        })
+        ;
       }
 
       @Override

--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
@@ -959,7 +959,9 @@ private MCSCategory stringToMCSCategory(String cat){
   @Override
   public void exit() {
   }
-
+  private static MessageParams getFatalErrorMessage(Throwable err){
+    return new MessageParams(MessageType.Error, "Fatal error during parsing: " + err.getMessage() + ".\nPlease report this issue on GitHub with this error message (https://github.com/kind2-mc/kind2-language-server/issues)");
+  }
   @Override
   public TextDocumentService getTextDocumentService() {
     return new TextDocumentService() {
@@ -973,7 +975,7 @@ private MCSCategory stringToMCSCategory(String cat){
           client.updateComponents(uri);
         })
         .exceptionally(ex -> {
-            client.showMessage(new MessageParams(MessageType.Error, "Fatal error during parsing: " + ex.getMessage()));
+            client.showMessage(getFatalErrorMessage(ex));
             return null;
         })
         ;
@@ -989,7 +991,7 @@ private MCSCategory stringToMCSCategory(String cat){
           client.updateComponents(uri);
         })
         .exceptionally(ex -> {
-            client.showMessage(new MessageParams(MessageType.Error, "Fatal error during parsing: " + ex.getMessage()));
+            client.showMessage(getFatalErrorMessage(ex));
             return null;
         })
         ;


### PR DESCRIPTION
LSP now properly shows an error in the VSCode extension when the call to parse throws an exception.