### PR TITLE
Add support for sending and receiving incremental results

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'edu.uiowa.cs.clc:kind2-java-api:0.5.5'
+  implementation 'edu.uiowa.cs.clc:kind2-java-api:0.6.0'
   implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.13.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'edu.uiowa.cs.clc:kind2-java-api:0.7.0'
+  implementation 'edu.uiowa.cs.clc:kind2-java-api:0.8.0'
   implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.13.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'

--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageClient.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageClient.java
@@ -1,5 +1,6 @@
 package edu.uiowa.kind2.lsp;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
@@ -28,4 +29,23 @@ interface Kind2LanguageClient extends LanguageClient {
    */
   @JsonRequest("kind2/getDefaultZ3Path")
   CompletableFuture<String> getDefaultZ3Path();
+
+
+  @JsonNotification("kind2/checkResultUpdate")
+  void checkResultUpdate(String uri, String name, List<String> values);
+
+  @JsonNotification("kind2/checkComplete")
+  void checkComplete(String uri, String name);
+
+  @JsonNotification("kind2/minimalCutSetResultUpdate")
+  void minimalCutSetResultUpdate(String uri, String name, List<String> values);
+
+  @JsonNotification("kind2/minimalCutSetComplete")
+  void minimalCutSetComplete(String uri, String name);
+
+  @JsonNotification("kind2/realizabilityResultUpdate")
+  void realizabilityResultUpdate(String uri, String name, List<String> values);
+
+  @JsonNotification("kind2/realizabilityComplete")
+  void realizabilityComplete(String uri, String name);
 }

--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
@@ -266,7 +266,8 @@ public class Kind2LanguageServer
       if (parseResults.containsKey(uri)) {
         try {
           for (AstInfo info : parseResults.get(uri).getAstInfos()) {
-            if (info instanceof NodeInfo || info instanceof FunctionInfo || info instanceof TypeDeclInfo) {
+            if (info instanceof NodeInfo || info instanceof FunctionInfo || info instanceof TypeDeclInfo || info instanceof ConstDeclInfo) {
+              client.logMessage(new MessageParams(MessageType.Info, info.getJson()));
               components.add(replacePathWithUri(info.getJson(), uri,
                   info.getFile() == null ? new URI(uri).getPath()
                       : info.getFile()));
@@ -282,7 +283,7 @@ public class Kind2LanguageServer
   }
 
   @JsonRequest(value = "kind2/minimalCutSet", useSegment = false)
-  public CompletableFuture<List<String>> minimalCutSet(String uri, String name) {
+  public CompletableFuture<List<String>> minimalCutSet(String uri, String name, String compKind) {
     return CompletableFutures.computeAsync(cancelToken -> {
       client.logMessage(new MessageParams(MessageType.Info,
           "Checking minimal cut sets of component " + name + " in " + uri + "..."));
@@ -303,7 +304,7 @@ public class Kind2LanguageServer
         if (workingDirectory == null) {
           workingDirectory = client.workspaceFolders().get().get(0).getUri();
         }
-        Kind2Api api = getCheckKind2Api(name, false);
+        Kind2Api api = getCheckKind2Api(name, compKind);
         api.enable(Module.MCS);
         api.includeDir(Paths.get(new URI(uri)).getParent().toString());
         String filepath = computeRelativeFilepath(workingDirectory, uri);
@@ -356,7 +357,7 @@ public class Kind2LanguageServer
   }
 
   @JsonRequest(value = "kind2/check", useSegment = false)
-  public CompletableFuture<List<String>> check(String uri, String name) {
+  public CompletableFuture<List<String>> check(String uri, String name, String compKind) {
     return CompletableFutures.computeAsync(cancelToken -> {
       client.logMessage(new MessageParams(MessageType.Info,
           "Checking component " + name + " in " + uri + "..."));
@@ -377,7 +378,7 @@ public class Kind2LanguageServer
         if (workingDirectory == null) {
           workingDirectory = client.workspaceFolders().get().get(0).getUri();
         }
-        Kind2Api api = getCheckKind2Api(name, false);
+        Kind2Api api = getCheckKind2Api(name, compKind);
         api.includeDir(Paths.get(new URI(uri)).getParent().toString());
         String filepath = computeRelativeFilepath(workingDirectory, uri);
         api.setFakeFilepath(filepath);
@@ -459,7 +460,7 @@ public class Kind2LanguageServer
   }
 
   @JsonRequest(value = "kind2/realizability", useSegment = false)
-  public CompletableFuture<List<String>> realizability(String uri, String name, boolean typeDecl) {
+  public CompletableFuture<List<String>> realizability(String uri, String name, String compKind) {
     return CompletableFutures.computeAsync(cancelToken -> {
       client.logMessage(new MessageParams(MessageType.Info,
           "Checking realizability of component " + name + " in " + uri + "..."));
@@ -480,7 +481,7 @@ public class Kind2LanguageServer
         if (workingDirectory == null) {
           workingDirectory = client.workspaceFolders().get().get(0).getUri();
         }
-        Kind2Api api = getCheckKind2Api(name, typeDecl);
+        Kind2Api api = getCheckKind2Api(name, compKind);
         api.includeDir(Paths.get(new URI(uri)).getParent().toString());
         String filepath = computeRelativeFilepath(workingDirectory, uri);
         api.setFakeFilepath(filepath);
@@ -830,7 +831,7 @@ private MCSCategory stringToMCSCategory(String cat){
     return api;
   }
 
-  public Kind2Api getCheckKind2Api(String name, boolean typeDecl)
+  public Kind2Api getCheckKind2Api(String name, String compKind)
       throws InterruptedException, ExecutionException {
     ConfigurationItem kind2Options = new ConfigurationItem();
     kind2Options.setSection("kind2");
@@ -915,10 +916,19 @@ private MCSCategory stringToMCSCategory(String cat){
       otherOptions.add(option.getAsString());
     }
     api.setOtherOptions(otherOptions);
-    if (typeDecl) {
-      api.setLusMainType(name);
-    } else {
-      api.setLusMain(name);
+    switch(compKind){
+      case "paramDecl":
+      case "constDecl":
+        api.setLusMainConst(name);
+        break;
+      case "nodeDecl":
+        api.setLusMain(name);
+        break;
+      case "typeDecl":
+        api.setLusMainType(name);
+        break;
+      default:
+        throw new RuntimeException("Component kind must be of the type \"constDecl\",\"paramDecl\",\"typeDecl\", or \"nodeDecl\". Got " + compKind);
     }
     return api;
   }
@@ -945,7 +955,7 @@ private MCSCategory stringToMCSCategory(String cat){
   public CompletableFuture<List<String>> getKind2Cmd(String uri, String main) {
     return CompletableFuture.supplyAsync(() -> {
       try {
-        Kind2Api api = getCheckKind2Api(main, false);
+        Kind2Api api = getCheckKind2Api(main, "nodeDecl");
         List<String> cmd = api.getOptions();
         cmd.set(0, Kind2Api.KIND2);
         cmd.add(new URI(uri).getPath());

--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
@@ -83,6 +83,7 @@ import edu.uiowa.cs.clc.kind2.results.Property;
 import edu.uiowa.cs.clc.kind2.results.Result;
 import edu.uiowa.cs.clc.kind2.results.RealizabilityResult;
 import edu.uiowa.cs.clc.kind2.results.TypeDeclInfo;
+import edu.uiowa.cs.clc.kind2.api.ResultListener;
 
 /**
  * LanguageServer
@@ -300,6 +301,13 @@ public class Kind2LanguageServer
         }
       };
 
+      ResultListener listener = new ResultListener() {
+          public void onUpdate(Result result){
+            List<String> json = handleMCSResult(result, uri);
+            client.minimalCutSetResultUpdate(uri, name,json);
+          } 
+        };
+
       try {
         if (workingDirectory == null) {
           workingDirectory = client.workspaceFolders().get().get(0).getUri();
@@ -311,7 +319,8 @@ public class Kind2LanguageServer
         api.setFakeFilepath(filepath);
         api.execute(getText(uri), 
                             result, 
-                            monitor);
+                            monitor,
+                            listener);
       } catch (Kind2Exception | IOException | URISyntaxException
           | InterruptedException | ExecutionException e) {
         throw new ResponseErrorException(new ResponseError(
@@ -324,8 +333,12 @@ public class Kind2LanguageServer
         // Throw an exception for the launcher to handle.
         cancelToken.checkCanceled();
       }
+      return handleCheckResult(result, uri);
+    });
+  }
 
-      for (Map.Entry<String, NodeResult> entry : result.getResultMap()
+  private List<String> handleMCSResult(Result result, String uri){
+    for (Map.Entry<String, NodeResult> entry : result.getResultMap()
           .entrySet()) {
         analysisResults.get(uri).put(entry.getKey(), entry.getValue());
       }
@@ -353,7 +366,6 @@ public class Kind2LanguageServer
       List<String> nodeResults = new ArrayList<>();
       nodeResults.add("{\"mcsAnalysis\": " + mcss.toString() + "}");
       return nodeResults;
-    });
   }
 
   @JsonRequest(value = "kind2/check", useSegment = false)
@@ -381,10 +393,20 @@ public class Kind2LanguageServer
         Kind2Api api = getCheckKind2Api(name, compKind);
         api.includeDir(Paths.get(new URI(uri)).getParent().toString());
         String filepath = computeRelativeFilepath(workingDirectory, uri);
+
+        ResultListener listener = new ResultListener() {
+          public void onUpdate(Result result){
+            List<String> json = handleCheckResult(result, uri);
+            client.checkResultUpdate(uri, name,json);
+          } 
+        };
+
         api.setFakeFilepath(filepath);
         api.execute(getText(uri), 
                             result, 
-                            monitor);
+                            monitor,
+                            listener
+                          );
       } catch (Kind2Exception | IOException | URISyntaxException
           | InterruptedException | ExecutionException e) {
         throw new ResponseErrorException(new ResponseError(
@@ -397,7 +419,13 @@ public class Kind2LanguageServer
         // Throw an exception for the launcher to handle.
         cancelToken.checkCanceled();
       }
+      client.checkComplete(uri, name);
+      return handleCheckResult(result, uri);
+    });
+  }
 
+  private List<String> handleCheckResult(Result result, String uri) {
+    
       for (Map.Entry<String, NodeResult> entry : result.getResultMap()
           .entrySet()) {
         analysisResults.get(uri).put(entry.getKey(), entry.getValue());
@@ -456,9 +484,7 @@ public class Kind2LanguageServer
       }
 
       return nodeResults;
-    });
   }
-
   @JsonRequest(value = "kind2/realizability", useSegment = false)
   public CompletableFuture<List<String>> realizability(String uri, String name, String compKind) {
     return CompletableFutures.computeAsync(cancelToken -> {
@@ -476,6 +502,13 @@ public class Kind2LanguageServer
         public void done() {
         }
       };
+      ResultListener listener = new ResultListener() {
+          public void onUpdate(Result result){
+            List<String> json = handleRealizabilityResult(result, uri);
+            client.realizabilityResultUpdate(uri, name, json);
+          } 
+        };
+
 
       try {
         if (workingDirectory == null) {
@@ -485,12 +518,11 @@ public class Kind2LanguageServer
         api.includeDir(Paths.get(new URI(uri)).getParent().toString());
         String filepath = computeRelativeFilepath(workingDirectory, uri);
         api.setFakeFilepath(filepath);
-        ArrayList<Module> options = new ArrayList<>();
-        options.add(Module.CONTRACTCK);
+        api.enable(Module.CONTRACTCK);
         api.execute(getText(uri), 
                             result, 
                             monitor,
-                            options);
+                            listener);
       } catch (Kind2Exception | IOException | URISyntaxException
           | InterruptedException | ExecutionException e) {
         throw new ResponseErrorException(new ResponseError(
@@ -503,8 +535,13 @@ public class Kind2LanguageServer
         // Throw an exception for the launcher to handle.
         cancelToken.checkCanceled();
       }
+      return handleRealizabilityResult(result, uri);
+      
+    });
+  }
 
-      for (Map.Entry<String, NodeResult> entry : result.getResultMap()
+  private List<String> handleRealizabilityResult(Result result, String uri){
+    for (Map.Entry<String, NodeResult> entry : result.getResultMap()
           .entrySet()) {
         analysisResults.get(uri).put(entry.getKey(), entry.getValue());
       }
@@ -530,15 +567,16 @@ public class Kind2LanguageServer
 
           // Add realizability info
           RealizabilityResult res = analysis.getRealizabilityResult();
-          json = json.substring(0, json.length() - 2) + ",\"realizabilityResult\": " + "\"" + res.toString() + "\" ,"+ getConflictingSetOf(result, analysis.getContext())  + '}';
-          analyses.add(json);
+          if (res != null){
+            json = json.substring(0, json.length() - 2) + ",\"realizabilityResult\": " + "\"" + res.toString() + "\" ,"+ getConflictingSetOf(result, analysis.getContext())  + '}';
+            analyses.add(json);
+          }
         }
         String json = "{\"name\": \"" + entry.getKey() + "\",\"analyses\": "
             + analyses.toString() + "}";
         nodeResults.add(json);
       }
       return nodeResults;
-    });
   }
 
   private String getConflictingSetOf(Result result, String context){

--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
@@ -569,11 +569,13 @@ public class Kind2LanguageServer
           String json = analysis.getJson();
 
           // Add realizability info
+          json = json.substring(0, json.length() - 2) ;
           RealizabilityResult res = analysis.getRealizabilityResult();
           if (res != null){
-            json = json.substring(0, json.length() - 2) + ",\"realizabilityResult\": " + "\"" + res.toString() + "\" ,"+ getConflictingSetOf(result, analysis.getContext())  + '}';
-            analyses.add(json);
+            json = json + ",\"realizabilityResult\": " + "\"" + res.toString() + "\" ,"+ getConflictingSetOf(result, analysis.getContext()) ;
           }
+          json += '}';
+          analyses.add(json);
         }
         String json = "{\"name\": \"" + entry.getKey() + "\",\"analyses\": "
             + analyses.toString() + "}";

--- a/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
+++ b/src/main/java/edu/uiowa/kind2/lsp/Kind2LanguageServer.java
@@ -334,7 +334,8 @@ public class Kind2LanguageServer
         // Throw an exception for the launcher to handle.
         cancelToken.checkCanceled();
       }
-      return handleCheckResult(result, uri);
+      client.minimalCutSetComplete(uri, name);
+      return handleMCSResult(result, uri);
     });
   }
 
@@ -536,6 +537,7 @@ public class Kind2LanguageServer
         // Throw an exception for the launcher to handle.
         cancelToken.checkCanceled();
       }
+      client.realizabilityComplete(uri, name);
       return handleRealizabilityResult(result, uri);
       
     });


### PR DESCRIPTION
Update LSP to handle continuous results sent by the API and pass it on to the VS Code extension incrementally. 

This will version of the LSP depends on the VS Code, Java API, and Kind 2 OCaml PRs of the same name